### PR TITLE
feat: add an enarx stars button that links to the repo

### DIFF
--- a/src/root_get.html
+++ b/src/root_get.html
@@ -2,6 +2,9 @@
 <html>
 
 <body>
+    <!-- https://ghbtns.com/#star -->
+    <iframe src="https://ghbtns.com/github-btn.html?user=enarx&repo=enarx&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+    <br>
     <a id="auth" href="/login">Login</a><span id="message"></span>
     <form enctype="multipart/form-data" method="post">
         <textarea name="toml" rows="16" style="width: 80%" autofocus>


### PR DESCRIPTION
This PR is related to #3 however in order to add a working star button on the page we need the `public_repo` scope (if we want to go in that direction)