### PR TITLE
feat: frontend messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "enarx-config-86d3ad9",
  "num_cpus",
  "once_cell",
  "openidconnect",
@@ -250,6 +251,16 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "enarx-config-86d3ad9"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a5297b94b2447bd34ac4bbf5ad3a3df7945ccfd3a81ef3fe83465bc38c1abb"
+dependencies = [
+ "serde",
+ "url",
+]
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -169,6 +169,7 @@ in
       anyhow = rustPackages."registry+https://github.com/rust-lang/crates.io-index".anyhow."1.0.58" { inherit profileName; };
       axum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".axum."0.5.11" { inherit profileName; };
       clap = rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."3.2.8" { inherit profileName; };
+      enarx_config_86d3ad9 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".enarx-config-86d3ad9."0.6.0" { inherit profileName; };
       num_cpus = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.13.1" { inherit profileName; };
       once_cell = rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.13.0" { inherit profileName; };
       openidconnect = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openidconnect."2.3.2" { inherit profileName; };
@@ -375,6 +376,17 @@ in
     version = "1.7.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"; };
+  });
+  
+  "registry+https://github.com/rust-lang/crates.io-index".enarx-config-86d3ad9."0.6.0" = overridableMkRustCrate (profileName: rec {
+    name = "enarx-config-86d3ad9";
+    version = "0.6.0";
+    registry = "registry+https://github.com/rust-lang/crates.io-index";
+    src = fetchCratesIo { inherit name version; sha256 = "17a5297b94b2447bd34ac4bbf5ad3a3df7945ccfd3a81ef3fe83465bc38c1abb"; };
+    dependencies = {
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.138" { inherit profileName; };
+      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.2.2" { inherit profileName; };
+    };
   });
   
   "registry+https://github.com/rust-lang/crates.io-index".encoding_rs."0.8.31" = overridableMkRustCrate (profileName: rec {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ openidconnect = { version = "2.3.1", default-features = false, features = ["ureq
 toml = { version = "0.5.9", default-features = false }
 num_cpus = "1.13.1"
 serde = { version = "1.0.136", default-features = false }
+# TODO: use enarx-config when a new version is published
+enarx-config-86d3ad9 = { version = "0.6.0", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/login", get(auth::login))
         .route("/logout", get(auth::logout))
         .route("/authorized", get(auth::authorized))
+        .route("/config-template.toml", get(config_template_toml))
         .route("/:uuid/", get(uuid_get))
         .route("/:uuid/out", post(uuid_out_post))
         .route("/:uuid/err", post(uuid_err_post))
@@ -328,6 +329,10 @@ async fn root_post(
     });
 
     Ok((StatusCode::SEE_OTHER, [("Location", format!("/{}", uuid))]))
+}
+
+async fn config_template_toml() -> &'static str {
+    enarx_config_86d3ad9::CONFIG_TEMPLATE
 }
 
 async fn uuid_get(

--- a/src/root_get.html
+++ b/src/root_get.html
@@ -10,7 +10,7 @@
 <body>
     <nav class="navbar is-light" role="navigation" aria-label="main navigation">
         <div class="navbar-brand">
-            <a class="navbar-item" href="#">
+            <a class="navbar-item" href="https://enarx.dev">
                 <img
                     src="https://raw.githubusercontent.com/enarx/website/main/static/assets/images/enarx-word-black-300x750.png">
             </a>

--- a/src/root_get.html
+++ b/src/root_get.html
@@ -54,6 +54,12 @@
                 </div>
             </article>
 
+            <div class="content">
+                <h3>Enarx Demo</h3>
+                <p>Run a Wasm payload in an Enarx Keep. Learn more from <a href="https://enarx.dev/">Enarx.dev</a> and
+                    star us on <a href="https://github.com/enarx/enarx">GitHub</a>.</p>
+            </div>
+
             <form enctype="multipart/form-data" method="post">
                 <div id="upload_file" class="file has-name">
                     <label class="file-label">
@@ -74,6 +80,7 @@
                 <input id="upload_submit" type="submit" class="button" value="Deploy Wasm workload" />
                 <br />
                 <br />
+                <a href="https://enarx.dev/docs/running/enarx_toml">Enarx.toml</a>:
                 <textarea class="textarea" name="toml" autofocus>
 [[files]]
 kind = "stdin"

--- a/src/root_get.html
+++ b/src/root_get.html
@@ -55,7 +55,7 @@
             </article>
 
             <div class="content">
-                <h3>Enarx Demo</h3>
+                <h3>Enarx Demo - Secured by <a href="https://www.profian.com">Profian</a></h3>
                 <p>Run a Wasm payload in an Enarx Keep. Learn more from <a href="https://enarx.dev/">Enarx.dev</a> and
                     star us on <a href="https://github.com/enarx/enarx">GitHub</a>.</p>
             </div>

--- a/src/root_get.html
+++ b/src/root_get.html
@@ -11,8 +11,8 @@
     <nav class="navbar is-light" role="navigation" aria-label="main navigation">
         <div class="navbar-brand">
             <a class="navbar-item" href="#">
-                <img src="https://raw.githubusercontent.com/enarx/website/main/static/img/assets/images/enarx-black-100-bg.png"
-                    width="28" height="28">
+                <img
+                    src="https://raw.githubusercontent.com/enarx/website/main/static/assets/images/enarx-word-black-300x750.png">
             </a>
 
             <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false"

--- a/src/root_get.html
+++ b/src/root_get.html
@@ -82,6 +82,7 @@
                 <br />
                 <a href="https://enarx.dev/docs/running/enarx_toml">Enarx.toml</a>:
                 <textarea class="textarea" name="toml" autofocus>
+# This configuration enables forwarding of stdin, stdout, and stderr.
 [[files]]
 kind = "stdin"
 

--- a/src/root_get.html
+++ b/src/root_get.html
@@ -81,22 +81,22 @@
                 <br />
                 <br />
                 <a href="https://enarx.dev/docs/running/enarx_toml">Enarx.toml</a>:
-                <textarea class="textarea" name="toml" autofocus>
-# This configuration enables forwarding of stdin, stdout, and stderr.
-[[files]]
-kind = "stdin"
-
-[[files]]
-kind = "stdout"
-
-[[files]]
-kind = "stderr"
-</textarea>
+                <textarea class="textarea" name="toml" autofocus></textarea>
                 <br />
             </form>
         </div>
     </section>
     <script>
+        function httpGetAsync(theUrl, callback) {
+            var xmlHttp = new XMLHttpRequest();
+            xmlHttp.onreadystatechange = function () {
+                if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
+                    callback(xmlHttp.responseText);
+            }
+            xmlHttp.open("GET", theUrl, true); // true for asynchronous 
+            xmlHttp.send(null);
+        }
+
         var authenticated = document.cookie.indexOf("SESSION") !== -1;
 
         var fileInput = document.querySelector('#upload_file input[type=file]');
@@ -123,6 +123,14 @@ kind = "stderr"
             uploadSubmit.disabled = true;
             messageDiv.innerText = "please login with GitHub to submit Wasm workloads";
         }
+
+        httpGetAsync(
+            "/config-template.toml",
+            function (response) {
+                var textarea = window.document.getElementsByTagName("textarea")[0];
+                textarea.value = response;
+            }
+        );
     </script>
 
 </body>


### PR DESCRIPTION
Closes #55 and #58

![image](https://user-images.githubusercontent.com/51100439/179284051-a5d15a8d-5f9c-422d-a0ac-551df31f45f5.png)

![image](https://user-images.githubusercontent.com/51100439/179767803-edbfe618-d9f6-4c5e-91bb-d0aba563f496.png)

also pulls the example config from [`enarx-config::CONFIG_TEMPLATE`](https://github.com/enarx/enarx/blob/main/crates/enarx-config/src/lib.rs#L18)