### PR TITLE
fix: several issues related to workload output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use uuid::Uuid;
 
 const ENARX_REPO: &str = "enarx/enarx";
-const READ_TIMEOUT: Duration = Duration::from_secs(5);
+// TODO: raise this when this is fixed: https://github.com/profianinc/benefice/issues/75
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
 const TOML_MAX: usize = 256 * 1024; // 256 KiB
 
 #[allow(dead_code)]

--- a/templates/uuid_get.html
+++ b/templates/uuid_get.html
@@ -39,7 +39,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                 })
                 .then((response) => {
                     let console = document.getElementById('console');
-                    console.innerHTML = console.innerHTML + response.replace(/(?:\r\n|\r|\n)/g, '<br>');
+                    console.innerHTML = console.innerHTML + response;
                     console.scrollTop = console.scrollHeight;
                     update(kind);
                 });
@@ -91,8 +91,8 @@ SPDX-License-Identifier: AGPL-3.0-only
         </h2>
       </div>
       <div class="container">
-        <div id="console">
-        </div>
+        <pre id="console">
+        </pre>
       </div>
     </section>
     <section class="bd-index-section" style="--bd-section-h: 229deg;">


### PR DESCRIPTION
Closes #61

This also greatly mitigates against rate limiting by auth0.. which usually occurs as a result of the output of a workload being left open for more than around 30 seconds. This often leads users to believe their session has expired and to "log in" again.

By skipping the auths by caching the session in the workload state being executed, the user can query stdout and stderr much more frequently without any issues.. and the logs don't get terminated by failed auth.

![??](https://user-images.githubusercontent.com/51100439/180375983-0d154753-7312-4334-a596-c93b598dba17.gif)

(this job will run forever, and can not be stopped #47)