### PR TITLE
fix: workload management

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -460,6 +460,14 @@ async fn root_post(
     tokio::spawn(async move {
         // Convert from minutes to seconds.
         sleep(Duration::from_secs(ctx.timeout * 60)).await;
+
+        // Stop running the workload
+        if let Some(state) = OUT.write().await.get(&uuid) {
+            let _ = state.lock().await.exec.kill().await;
+        }
+
+        // Remove the workload state completely if it still exists
+        sleep(Duration::from_secs(5 * 60)).await;
         OUT.write().await.remove(&uuid);
     });
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -2,10 +2,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use axum::response::Redirect;
+use uuid::Uuid;
 
 /// Redirect the user to the home page with no warnings or errors.
 pub fn home() -> Redirect {
     Redirect::to("/")
+}
+
+/// Redirect the user to a workload that is currently running.
+pub fn workload(uuid: &Uuid) -> Redirect {
+    Redirect::to(&format!("/{}/", uuid))
 }
 
 /// The user has no session and has likely been logged out.

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -3,6 +3,11 @@
 
 use axum::response::Redirect;
 
+/// Redirect the user to the home page with no warnings or errors.
+pub fn home() -> Redirect {
+    Redirect::to("/")
+}
+
 /// The user has no session and has likely been logged out.
 pub fn no_session() -> Redirect {
     Redirect::to("/?message=no_session")
@@ -18,9 +23,9 @@ pub fn too_many_workloads() -> Redirect {
     Redirect::to("/?message=too_many_workloads")
 }
 
-/// A user already has a running workload.
-pub fn workload_running() -> Redirect {
-    Redirect::to("/?message=workload_running")
+/// The user has successfully terminated a workload.
+pub fn workload_killed() -> Redirect {
+    Redirect::to("/?message=workload_killed")
 }
 
 /// An internal error occurred.

--- a/templates/root_get.html
+++ b/templates/root_get.html
@@ -159,8 +159,10 @@ SPDX-License-Identifier: AGPL-3.0-only
                 messageHTML.push("Too many workloads are running on this server! Please try again later.");
                 break;
             }
-            case 'workload_running': {
-                messageHTML.push("You already have a workload running.");
+            case 'workload_killed': {
+                // Users probably don't care if the workload was killed.
+                // This is just here for testing.
+                // messageHTML.push("Workload killed successfully.");
                 break;
             }
             case 'internal_error': {

--- a/templates/uuid_get.html
+++ b/templates/uuid_get.html
@@ -79,7 +79,7 @@ SPDX-License-Identifier: AGPL-3.0-only
             <div class="navbar-end">
                 <div class="navbar-item">
                     <div class="buttons">
-                        <a class="button is-primary" id="auth" onclick="history.back()">
+                        <a class="button is-primary" id="auth" href="kill">
                             Go back
                         </a>
                     </div>


### PR DESCRIPTION
Closes #47, #74

This might make #5 unnecessary if we only want users to launch one job at a time.