### PR TITLE
fix: broken profian logo

### DIFF
--- a/templates/root_get.html
+++ b/templates/root_get.html
@@ -29,7 +29,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
             <span class="navbar-item">by</span>
 
-            <a class="navbar-item" href="https://profian.com">
+            <a class="navbar-item" href="https://profian.com" style="width: 100%">
                 <img src="https://try.enarx.dev/img/profian.svg">
             </a>
 

--- a/templates/uuid_get.html
+++ b/templates/uuid_get.html
@@ -60,7 +60,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
             <span class="navbar-item">by</span>
 
-            <a class="navbar-item" href="https://profian.com">
+            <a class="navbar-item" href="https://profian.com" style="width: 100%">
               <img src="https://try.enarx.dev/img/profian.svg">
             </a>
 


### PR DESCRIPTION
This css needs to be here or the logo looks like this

![image](https://user-images.githubusercontent.com/51100439/180856256-b5bb5d86-de95-481f-abb5-abd681d3e9b6.png)
