### PR TITLE
fix: add some redirects to root_post

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use axum::response::Redirect;
+
+/// The server is already running too many jobs.
+pub fn too_many_workloads() -> Redirect {
+    Redirect::to("/?message=too_many_workloads")
+}

--- a/templates/idx.html
+++ b/templates/idx.html
@@ -131,32 +131,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
         // SECURITY: Do not put query parameter values in messageHTML.
         switch (messageCode) {
-            case 'no_session': {
-                if (!authenticated) {
-                    messageHTML.push("It looks like you have been logged out.");
-                }
-                break;
-            }
-            case 'workload_not_found': {
-                if (authenticated) {
-                    messageHTML.push("The workload was not found or you are not permitted to view it.");
-                } else {
-                    messageHTML.push("You need to be logged in to view workloads.");
-                }
-                break;
-            }
             case 'too_many_workloads': {
                 messageHTML.push("Too many workloads are running on this server! Please try again later.");
-                break;
-            }
-            case 'workload_killed': {
-                // Users probably don't care if the workload was killed.
-                // This is just here for testing.
-                // messageHTML.push("Workload killed successfully.");
-                break;
-            }
-            case 'internal_error': {
-                messageHTML.push("An internal error occurred handling your request. Please try again or contact an administrator.");
                 break;
             }
             default: {


### PR DESCRIPTION
Closes #95 

- If a user already has a job running, just redirect to it.
- If too many workloads are running, show an error.

It looks like a lot of the previously used redirects aren't really needed right now but I'm going to add a few more in #83 