### PR TITLE
feat: save/load the drawbridge slug from a query param

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use crate::EXAMPLES;
+
 use askama::Template;
 use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Response};
@@ -20,6 +22,18 @@ pub struct IdxTemplate<'a> {
 #[derive(Template)]
 #[template(path = "job.html")]
 pub struct JobTemplate;
+
+impl JobTemplate {
+    fn get_slug_url(&self, slug: &str) -> String {
+        for example_slug in &*EXAMPLES {
+            if example_slug.contains(slug) {
+                return format!("/?slug={}", example_slug);
+            }
+        }
+
+        panic!("Slug {slug} not found in examples");
+    }
+}
 
 pub struct HtmlTemplate<T>(pub T);
 

--- a/templates/idx.html
+++ b/templates/idx.html
@@ -67,9 +67,12 @@
             </article>
             <div class="content">
                 <p>
-                    <strong>Try Enarx</strong> allows you to run a <strong>WebAssembly</strong> workload in an encrypted <strong>Enarx Keep</strong>.
-                    You can either <strong>select a demo</strong> to see it working (from <strong>Drawbridge</strong>, an Enarx package registry) or <strong>upload a Wasm file</strong> along with <a
-                    href="https://enarx.dev/docs/running/enarx_toml" target="_blank">the Enarx runtime configuration</a>.
+                    <strong>Try Enarx</strong> allows you to run a <strong>WebAssembly</strong> workload in an encrypted
+                    <strong>Enarx Keep</strong>.
+                    You can either <strong>select a demo</strong> to see it working (from <strong>Drawbridge</strong>,
+                    an Enarx package registry) or <strong>upload a Wasm file</strong> along with <a
+                        href="https://enarx.dev/docs/running/enarx_toml" target="_blank">the Enarx runtime
+                        configuration</a>.
                 </p>
                 <p>
                     {% if star %}

--- a/templates/idx.html
+++ b/templates/idx.html
@@ -176,6 +176,7 @@
         var enarxTomlReadOnlyDiv = window.document.getElementById("enarxTomlReadOnly");
         var editorDiv = window.document.getElementById("editorDiv");
         var lastSlug = '';
+        var customSlugValue = '[CUSTOM]';
 
         function showTag(tag) {
             if (tag) {
@@ -276,7 +277,7 @@
         }
 
         function customSlugSelected() {
-            return selectedSlugOption() == '[CUSTOM]';
+            return selectedSlugOption() == customSlugValue;
         }
 
         function customSlug() {
@@ -292,6 +293,29 @@
                 return customSlug();
             } else {
                 return selectedSlugOption();
+            }
+        }
+
+        function exampleSlugExists(slug) {
+            return document.getElementById('slugSelect').innerHTML.indexOf(slug) !== -1;
+        }
+
+        function setSlugParam(slug) {
+            if (!slug) {
+                queryParams.delete('slug');
+            } else {
+                queryParams.set('slug', slug);
+            }
+
+            history.replaceState(null, null, "?" + queryParams.toString());
+        }
+
+        function setSlugField(slug) {
+            if (exampleSlugExists(slug)) {
+                window.document.getElementById('slugSelect').value = slug;
+            } else {
+                window.document.getElementById('slugSelect').value = customSlugValue;
+                window.document.getElementById('customSlug').value = slug;
             }
         }
 
@@ -419,6 +443,7 @@
                         showTag(uploadSubmit);
                     }
 
+                    setSlugParam(currentSlug());
                     showTag(editorDiv);
                     showTag(enarxTomlReadOnlyDiv);
                     enarxTomlEditor.setReadOnly(true);
@@ -445,6 +470,7 @@
                         hideTag(uploadSubmit);
                     }
 
+                    setSlugParam();
                     showTag(editorDiv);
                     hideTag(enarxTomlReadOnlyDiv);
                     enarxTomlEditor.setReadOnly(false);
@@ -498,6 +524,15 @@
 
                 lastSlug = slug;
             }
+        }
+
+        var querySlug = queryParams.get('slug');
+
+        if (querySlug) {
+            var form = window.document.getElementById('workloadForm')
+            form.elements["workloadType"].value = 'drawbridge';
+            setSlugField(querySlug);
+            updateWorkloadForm();
         }
 
         setInterval(refreshEnarxToml, 1000);

--- a/templates/idx.html
+++ b/templates/idx.html
@@ -80,7 +80,7 @@
                 </p>
             </div>
             {% if user %}
-            <form enctype="multipart/form-data" method="post" onsubmit="submitWorkloadForm()">
+            <form id="workloadForm" enctype="multipart/form-data" method="post" onsubmit="submitWorkloadForm()">
                 <div class="field">
                     <label>Retrieve workload from: </label>
                     <div class="control">
@@ -529,7 +529,7 @@
         var querySlug = queryParams.get('slug');
 
         if (querySlug) {
-            var form = window.document.getElementById('workloadForm')
+            var form = window.document.getElementById('workloadForm');
             form.elements["workloadType"].value = 'drawbridge';
             setSlugField(querySlug);
             updateWorkloadForm();

--- a/templates/job.html
+++ b/templates/job.html
@@ -64,14 +64,14 @@
         });
     }
 
-    function kill() {
+    function kill(url) {
       return fetch('/', { method: 'DELETE' })
         .then((response) => {
           if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
+            console.error(`HTTP error! Status: ${response.status}`);
           }
 
-          window.location.replace("/");
+          window.location.replace(url);
         })
     }
 
@@ -110,7 +110,7 @@
     <div class="container" id="output">
       <pre id="console">Starting workload...<br/></pre>
       <br />
-      <button class="button is-danger" onclick="kill()">Kill</button>
+      <button class="button is-danger" onclick="kill('/')">Kill</button>
     </div>
   </section>
   <section class="bd-index-section" style="--bd-section-h: 229deg;">
@@ -314,22 +314,42 @@
       </a>
     </div>
     <div class="bd-screenshots">
-      <a class="bd-screenshot " href="https://github.com/enarx/GreenhouseMonitor" target="_blank">
-        <img src="https://try.enarx.dev/img/greenhouse.png" width="700" height="350" alt="GreenhouseMonitor">
-        <button class="button is-info" style="width:100%; margin-top:10px;">Greenhouse Monitor</button>
-      </a>
-      <a class="bd-screenshot " href="https://github.com/enarx/cryptle" target="_blank">
-        <img src="https://try.enarx.dev/img/cryptle.png" width="700" height="350" alt="Cryptle">
-        <button class="button is-info" style="width:100%; margin-top:10px;">Cryptle</button>
-      </a>
-      <a class="bd-screenshot " href="https://github.com/enarx/codex/tree/main/Rust/tokio-http" target="_blank">
-        <img src="https://try.enarx.dev/img/tokio-minihttp.png" width="700" height="350" alt="Tokio Mini HTTP">
-        <button class="button is-info" style="width:100%; margin-top:10px;">Tokio Mini HTTP</button>
-      </a>
-      <a class="bd-screenshot " href="https://github.com/enarx/codex/tree/main/Rust/mio-echo-tcp" target="_blank">
-        <img src="https://try.enarx.dev/img/tokio-mio.png" width="700" height="350" alt="Mio TCP Echo Server">
-        <button class="button is-info" style="width:100%; margin-top:10px;">Mio TCP Echo Server</button>
-      </a>
+      <div>
+        <a class="bd-screenshot" href="https://github.com/enarx/GreenhouseMonitor" target="_blank">
+          <img src="https://try.enarx.dev/img/greenhouse.png" width="700" height="350" alt="GreenhouseMonitor">
+          <button class="button is-info" style="width:100%; margin-top:10px;">Greenhouse Monitor</button>
+        </a>
+        <button class="button is-primary" style="width:100%; margin-top:10px;"
+          data-href='{{ self.get_slug_url("greenhouse-monitor-csharp") }}'
+          onclick="kill(this.getAttribute('data-href'))">Deploy</button>
+      </div>
+      <div>
+        <a class="bd-screenshot" href="https://github.com/enarx/cryptle" target="_blank">
+          <img src="https://try.enarx.dev/img/cryptle.png" width="700" height="350" alt="Cryptle">
+          <button class="button is-info" style="width:100%; margin-top:10px;">Cryptle</button>
+        </a>
+        <button class="button is-primary" style="width:100%; margin-top:10px;"
+          data-href='{{ self.get_slug_url("cryptle-rust") }}'
+          onclick="kill(this.getAttribute('data-href'))">Deploy</button>
+      </div>
+      <div>
+        <a class="bd-screenshot" href="https://github.com/enarx/codex/tree/main/Rust/tokio-http" target="_blank">
+          <img src="https://try.enarx.dev/img/tokio-minihttp.png" width="700" height="350" alt="Tokio Mini HTTP">
+          <button class="button is-info" style="width:100%; margin-top:10px;">Tokio Mini HTTP</button>
+        </a>
+        <button class="button is-primary" style="width:100%; margin-top:10px;"
+          data-href='{{ self.get_slug_url("http-rust-tokio") }}'
+          onclick="kill(this.getAttribute('data-href'))">Deploy</button>
+      </div>
+      <div>
+        <a class="bd-screenshot" href="https://github.com/enarx/codex/tree/main/Rust/mio-echo-tcp" target="_blank">
+          <img src="https://try.enarx.dev/img/tokio-mio.png" width="700" height="350" alt="Mio TCP Echo Server">
+          <button class="button is-info" style="width:100%; margin-top:10px;">Mio TCP Echo Server</button>
+        </a>
+        <button class="button is-primary" style="width:100%; margin-top:10px;"
+          data-href='{{ self.get_slug_url("echo-tcp-rust-mio") }}'
+          onclick="kill(this.getAttribute('data-href'))">Deploy</button>
+      </div>
     </div>
   </section>
   <section class="bd-index-section" style="--bd-section-h: 330deg;">


### PR DESCRIPTION
Closes #93, #100 

http://127.0.0.1:3000/?slug=hello/world:0.1.0

![image](https://user-images.githubusercontent.com/51100439/182608004-b05bf0af-d0c5-4b93-8af5-ece177612897.png)

http://127.0.0.1:3000/?slug=examples/fibonacci-rust:0.2.0

![image](https://user-images.githubusercontent.com/51100439/182608108-65ca6bca-119a-427b-912e-3048951a741e.png)

Selecting slugs in the form will also change the url appropriately

These "Deploy" buttons kill the workload and redirect to /?slug=xx

![image](https://user-images.githubusercontent.com/51100439/182617244-40ce9350-6cd6-4225-80be-63efd124bc84.png)
