### PR TITLE
fix: the language/platform buttons

### DIFF
--- a/templates/idx.html
+++ b/templates/idx.html
@@ -325,23 +325,25 @@
         <div class="container">
             <div class="columns">
                 <div class="column">
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <div class="bd-tw-content">
-                            <a href="https://sgx.equinix.try.enarx.dev/" target="_blank"><img
-                                    src="https://try.enarx.dev/img/equinix_intel.png" alt="Intel on Equinix"></a>
-                        </div>
-                    </article>
+                    <a href="https://sgx.equinix.try.enarx.dev/" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/equinix_intel.png" alt="Intel on Equinix">
+                            </div>
+                        </article>
+                    </a>
                 </div>
                 <div class="column">
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <div class="bd-tw-content">
-                            <a href="https://snp.equinix.try.enarx.dev/" target="_blank"><img
-                                    src="https://try.enarx.dev/img/equinix_amd.png" alt="AMD on Equinix"></a>
-                        </div>
-                    </article>
+                    <a href="https://snp.equinix.try.enarx.dev/" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/equinix_amd.png" alt="AMD on Equinix">
+                            </div>
+                        </article>
+                    </a>
                 </div>
                 <div class="column">
-                    <article class="bd-tw bd-best-item bd-is-huge ">
+                    <article class="bd-tw bd-best-item bd-is-huge">
                         <header class="bd-tw-header">
                             <strong>Other platforms coming soon</strong>
                         </header>
@@ -374,117 +376,132 @@
         <div class="container">
             <div class="columns">
                 <div class="column">
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>C</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/C" target="_blank"><img
-                                    src="https://try.enarx.dev/img/c_128x128.png" alt="C"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>Rust</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/Rust" target="_blank"><img
-                                    src="https://try.enarx.dev/img/rust_128x128.png" alt="Rust"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>AssemblyScript</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/AssemblyScript" target="_blank"><img
-                                    src="https://try.enarx.dev/img/assemblyscript_128x128.png" alt="AssemblyScript"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>Python</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/Python" target="_blank"><img
-                                    src="https://try.enarx.dev/img/python_128x128.png" alt="Python"></a>
-                        </div>
-                    </article>
+                    <a href="https://enarx.dev/docs/webassembly/C" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>C</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/c_128x128.png" alt="C">
+                            </div>
+                        </article>
+                    </a>
+                    <a href="https://enarx.dev/docs/webassembly/Rust" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>Rust</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/rust_128x128.png" alt="Rust">
+                            </div>
+                        </article>
+                    </a>
+                    <a href="https://enarx.dev/docs/webassembly/AssemblyScript" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>AssemblyScript</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/assemblyscript_128x128.png" alt="AssemblyScript">
+                            </div>
+                        </article>
+                    </a>
+                    <!-- TODO: add this link back when it can run with Enarx -->
+                    <!-- <a href="https://enarx.dev/docs/webassembly/Python" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>Python</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/python_128x128.png" alt="Python">
+                            </div>
+                        </article>
+                    </a> -->
                 </div>
                 <div class="column">
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>C++</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/C++" target="_blank"><img
-                                    src="https://try.enarx.dev/img/cpp_128x128.png" alt="C++"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>Golang</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/Golang" target="_blank"><img
-                                    src="https://try.enarx.dev/img/golang_128x128.png" alt="Golang"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>JavaScript</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/JavaScript" target="_blank"><img
-                                    src="https://try.enarx.dev/img/javascript_128x128.png" alt="JavaScript"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>Swift</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/Swift" target="_blank"><img
-                                    src="https://try.enarx.dev/img/swift_128x128.png" alt="Swift"></a>
-                        </div>
-                    </article>
+                    <a href="https://enarx.dev/docs/webassembly/C++" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>C++</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/cpp_128x128.png" alt="C++">
+                            </div>
+                        </article>
+                    </a>
+                    <a href="https://enarx.dev/docs/webassembly/Golang" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>Golang</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/golang_128x128.png" alt="Golang">
+                            </div>
+                        </article>
+                    </a>
+                    <a href="https://enarx.dev/docs/webassembly/JavaScript" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>JavaScript</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/javascript_128x128.png" alt="JavaScript">
+                            </div>
+                        </article>
+                    </a>
+                    <a href="https://enarx.dev/docs/webassembly/Swift" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>Swift</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/swift_128x128.png" alt="Swift">
+                            </div>
+                        </article>
+                    </a>
                 </div>
                 <div class="column">
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>.NET</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/dotnet" target="_blank"><img
-                                    src="https://try.enarx.dev/img/csharp_128x128.png" alt=".NET"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>Ruby</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/Ruby" target="_blank"><img
-                                    src="https://try.enarx.dev/img/ruby_128x128.png" alt="Ruby"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>TypeScript</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="https://enarx.dev/docs/webassembly/TypeScript" target="_blank"><img
-                                    src="https://try.enarx.dev/img/typescript_128x128.png" alt="TypeScript"></a>
-                        </div>
-                    </article>
-                    <article class="bd-tw bd-best-item bd-is-huge ">
-                        <header class="bd-tw-header">
-                            <strong>Java</strong>
-                        </header>
-                        <div class="bd-tw-content">
-                            <a href="#"><img src="https://try.enarx.dev/img/java_128x128.png" alt="Java"></a>
-                        </div>
-                    </article>
+                    <a href="https://enarx.dev/docs/webassembly/dotnet" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>.NET</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/csharp_128x128.png" alt=".NET">
+                            </div>
+                        </article>
+                    </a>
+                    <a href="https://enarx.dev/docs/webassembly/Ruby" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>Ruby</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/ruby_128x128.png" alt="Ruby">
+                            </div>
+                        </article>
+                    </a>
+                    <a href="https://enarx.dev/docs/webassembly/TypeScript" target="_blank">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>TypeScript</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/typescript_128x128.png" alt="TypeScript">
+                            </div>
+                        </article>
+                    </a>
+                    <!-- TODO: add a link for java when it can run in Enarx -->
+                    <!-- <a href="#">
+                        <article class="bd-tw bd-best-item bd-is-huge">
+                            <header class="bd-tw-header">
+                                <strong>Java</strong>
+                            </header>
+                            <div class="bd-tw-content">
+                                <img src="https://try.enarx.dev/img/java_128x128.png" alt="Java">
+                            </div>
+                        </article>
+                    </a> -->
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Closes #164

- Make the entire button clickable.
- Remove link to running Python because doesn't work in Enarx yet.
- Remove broken link to Java.
