### PR TITLE
fix: use correct TTL and size limits when starred vs not

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,9 +262,9 @@ struct Limits {
 impl Limits {
     fn time_to_live(&self, star: bool) -> Duration {
         if star {
-            self.timeout_default
-        } else {
             self.timeout_starred
+        } else {
+            self.timeout_default
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,9 +271,9 @@ impl Limits {
     /// Get the maximum allowed wasm size in bytes.
     fn size(&self, star: bool) -> usize {
         let size_megabytes = if star {
-            self.size_limit_default
-        } else {
             self.size_limit_starred
+        } else {
+            self.size_limit_default
         };
         size_megabytes * 1024 * 1024
     }


### PR DESCRIPTION
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>