### PR TITLE
docs: fix codex links

### DIFF
--- a/templates/idx.html
+++ b/templates/idx.html
@@ -603,11 +603,11 @@
                 <img src="https://try.enarx.dev/img/cryptle.png" width="700" height="350" alt="Cryptle">
                 <button class="button is-info" style="width:100%; margin-top:10px;">Cryptle</button>
             </a>
-            <a class="bd-screenshot " href="https://github.com/enarx/codex/tree/main/Rust/tokio-http" target="_blank">
+            <a class="bd-screenshot " href="https://github.com/enarx/codex/tree/main/examples/rust/tokio/http" target="_blank">
                 <img src="https://try.enarx.dev/img/tokio-minihttp.png" width="700" height="350" alt="Tokio Mini HTTP">
                 <button class="button is-info" style="width:100%; margin-top:10px;">Tokio Mini HTTP</button>
             </a>
-            <a class="bd-screenshot " href="https://github.com/enarx/codex/tree/main/Rust/mio-echo-tcp" target="_blank">
+            <a class="bd-screenshot " href="https://github.com/enarx/codex/tree/main/examples/rust/mio/echo-tcp" target="_blank">
                 <img src="https://try.enarx.dev/img/tokio-mio.png" width="700" height="350" alt="Mio TCP Echo Server">
                 <button class="button is-info" style="width:100%; margin-top:10px;">Mio TCP Echo Server</button>
             </a>


### PR DESCRIPTION
Fix Codex links from the Wasm Gallery that got broken due to a recent restructure of the Codex repo.

Closes #212 

Signed-off-by: Nick Vidal <nick@profian.com>