### PR TITLE
build: update clap to 4.0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,23 +283,22 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
- "textwrap",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -310,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -459,6 +458,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -768,6 +788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +843,12 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "log"
@@ -879,7 +911,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1271,6 +1303,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,10 +1539,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
+name = "terminal_size"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
+dependencies = [
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "thiserror"
@@ -1980,12 +2030,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1994,10 +2065,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2006,16 +2089,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ askama = { version = "0.11.1", default-features = false }
 axum = { version = "0.5.17", default-features = false, features = ["headers", "json", "multipart", "query"] }
 axum-extra = { version = "0.3.7", default-features = false, features = ["cookie"] }
 base64 = { version = "0.13.1", default-features = false }
-clap = { version = "3.2.3", default-features = false, features = ["derive", "std"] }
+clap = { version = "4.0.26", default-features = false, features = ["derive", "error-context", "help", "std", "usage", "wrap_help"] }
 confargs = { version = "0.1.1", default-features = false }
 enarx-config = { version = "0.6.1", default-features = false }
 futures-util = { version = "0.3.23", default-features = false }

--- a/src/auth/key.rs
+++ b/src/auth/key.rs
@@ -12,6 +12,7 @@ use zeroize::Zeroize;
 
 type KeySize = <Aes128Gcm as NewAead>::KeySize;
 
+#[derive(Clone)]
 pub struct Key(aes_gcm::Key<KeySize>);
 
 impl Debug for Key {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,110 +100,110 @@ static EXAMPLES: OnceCell<Examples> = OnceCell::new();
 /// The configuration file must contain valid TOML table mapping argument
 /// names to their values.
 #[derive(Parser, Debug)]
-#[clap(author, version, about)]
+#[command(author, version, about)]
 struct Args {
     /// Address to bind to.
-    #[clap(long, default_value_t = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 3000))]
+    #[arg(long, default_value_t = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 3000))]
     addr: SocketAddr,
 
     /// Externally accessible root URL.
     /// For example: https://benefice.example.com
-    #[clap(long)]
+    #[arg(long)]
     url: auth::Url,
 
     /// Externally accessible domain name for serving demos.
     /// This should not be the same as the benefice server URL for security reasons.
     /// For example: demo.example.com
-    #[clap(long)]
+    #[arg(long)]
     demo_fqdn: String,
 
     /// Maximum jobs.
     /// Defaults to 16x the number of cores on the system.
-    #[clap(long, default_value_t = num_cpus::get() * 16)]
+    #[arg(long, default_value_t = num_cpus::get() * 16)]
     jobs: usize,
 
     /// Default file size limit (in MiB).
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     size_limit_default: usize,
 
     /// Starred file size limit (in MiB).
-    #[clap(long, default_value_t = 50)]
+    #[arg(long, default_value_t = 50)]
     size_limit_starred: usize,
 
     /// Default job timeout (in seconds).
-    #[clap(long, default_value_t = 5 * 60)]
+    #[arg(long, default_value_t = 5 * 60)]
     timeout_default: u64,
 
     /// Starred job timeout (in seconds).
-    #[clap(long, default_value_t = 15 * 60)]
+    #[arg(long, default_value_t = 15 * 60)]
     timeout_starred: u64,
 
     /// The lowest listen port to be allocated via the selected OCI container engine.
-    #[clap(long, default_value_t = 1024)]
+    #[arg(long, default_value_t = 1024)]
     port_min: u16,
 
     /// The highest listen port to be allocated via the selected OCI container engine.
-    #[clap(long, default_value_t = 65535)]
+    #[arg(long, default_value_t = 65535)]
     port_max: u16,
 
     /// The maximum number of listen ports a workload is allowed to have (0 to disable).
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     listen_max: u16,
 
     /// `ss` command to execute, for example `ss`.
-    #[clap(long, default_value = "ss")]
+    #[arg(long, default_value = "ss")]
     ss_command: OsString,
 
     /// OCI container engine command to execute, for example, `docker` or `podman`.
     /// This may also be an absolute path.
-    #[clap(long, default_value = "docker")]
+    #[arg(long, default_value = "docker")]
     oci_command: OsString,
 
     /// OCI image to use.
     /// Defaults to the last tested image from https://hub.docker.com/r/enarx/enarx
-    #[clap(long, default_value = "enarx/enarx:0.6.3")]
+    #[arg(long, default_value = "enarx/enarx:0.6.3")]
     oci_image: String,
 
     /// OpenID Connect issuer URL.
-    #[clap(long, default_value = "https://auth.profian.com/")]
+    #[arg(long, default_value = "https://auth.profian.com/")]
     oidc_issuer: auth::Url,
 
     /// OpenID Connect client ID.
-    #[clap(long)]
+    #[arg(long)]
     oidc_client: String,
 
     /// Path to a file containing OpenID Connect secret.
-    #[clap(long)]
+    #[arg(long)]
     oidc_secret: Option<secret::SecretFile<String>>,
 
     /// Key used to encrypt the session cookie.
-    #[clap(long)]
+    #[arg(long)]
     session_key: Option<secret::SecretFile<Key>>,
 
     /// Session cookie time to live (in minutes).
-    #[clap(long, default_value_t = 24 * 60)]
+    #[arg(long, default_value_t = 24 * 60)]
     session_ttl: u64,
 
     /// Runtime directory, where uploaded workloads and configs will be temporarily stored.
-    #[clap(long, default_value_os_t = temp_dir())]
+    #[arg(long, default_value_os_t = temp_dir())]
     runtime_dir: PathBuf,
 
     /// Devices to expose to the container.
-    #[clap(long)]
+    #[arg(long)]
     devices: Vec<PathBuf>,
 
     /// Paths to expose to the container.
     /// Usually, this would be `/var/run/aesmd/aesm.socket` on Intel SGX and `/var/cache/amd-sev` on AMD SEV.
-    #[clap(long)]
+    #[arg(long)]
     paths: Vec<PathBuf>,
 
     /// Whether to run the container in privileged mode.
-    #[clap(long)]
+    #[arg(long)]
     privileged: bool,
 
     /// Examples to be displayed on the examples page. If none are provided some built-in examples will be provided.
     /// This will be parsed as TOML.
-    #[clap(long)]
+    #[arg(long)]
     examples: Option<Examples>,
 }
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -8,7 +8,7 @@ use zeroize::Zeroizing;
 
 use crate::auth::Key;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SecretFile<T>(T);
 
 impl From<SecretFile<Key>> for Key {


### PR DESCRIPTION
This also adds a few new Clone derives in order to satisfy the requirements of Clap internals.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>