### PR TITLE
chore: update `humansize`, `toml`; suppress a clippy error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.7.2",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -333,7 +333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea7623826f70dd39cb095e90ce5690153d03091a5a4c2f38273e80af766587a"
 dependencies = [
  "anyhow",
- "toml",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -728,9 +728,12 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humansize"
-version = "1.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "hyper"
@@ -877,6 +880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +990,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1463,6 +1481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1780,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4.0.29", default-features = false, features = ["derive", "er
 confargs = { version = "0.1.1", default-features = false }
 enarx-config = { version = "0.6.1", default-features = false }
 futures-util = { version = "0.3.23", default-features = false }
-humansize = { version = "1.1.1", default-features = false }
+humansize = { version = "2.1.3", default-features = false, features = ["impl_style"] }
 num_cpus = { version = "1.14.0", default-features = false }
 once_cell = { version = "1.16.0", default-features = false }
 openidconnect = { version = "2.5.0", default-features = false, features = ["rustls-tls", "reqwest"] }
@@ -24,7 +24,7 @@ serde = { version = "1.0.150", default-features = false }
 serde_json = { version = "1.0.89", default-features = false, features = ["std"] }
 tempfile = { version = "3.3.0", default-features = false }
 tokio = { version = "1.22.0", default-features = false, features = ["macros", "process", "rt-multi-thread", "io-util", "fs", "sync"] }
-toml = { version = "0.5.9", default-features = false }
+toml = { version = "0.7.2", default-features = false, features = ["parse"] }
 tower-http = { version = "0.3.5", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.37", default-features = false, features = ["std", "release_max_level_info"] }
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["ansi", "env-filter", "std", "tracing-log", "json"] }

--- a/src/job.rs
+++ b/src/job.rs
@@ -58,6 +58,7 @@ async fn used_ports<T: FromIterator<u16>>(ss: impl AsRef<OsStr>) -> anyhow::Resu
 impl Job {
     /// Spawns a new job via selected OCI engine, it is not safe for concurrent use.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::let_underscore_future)]
     pub(crate) async fn spawn(
         id: String,
         workload: Workload,

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ use clap::Parser;
 use confargs::{args, prefix_char_filter, Toml};
 use enarx_config::{Config, File, Protocol};
 use futures_util::{stream, StreamExt};
-use humansize::{file_size_opts as options, FileSize};
+use humansize::FormatSize;
 use once_cell::sync::{Lazy, OnceCell};
 use serde_json::json;
 use tempfile::NamedTempFile;
@@ -279,12 +279,7 @@ impl Limits {
     }
 
     fn size_human(&self, star: bool) -> String {
-        self.size(star)
-            .file_size(options::CONVENTIONAL)
-            .unwrap_or_else(|e| {
-                error!(error = ?e, "Failed to get human readable size string");
-                "?".to_string()
-            })
+        self.size(star).format_size(humansize::DECIMAL)
     }
 }
 


### PR DESCRIPTION
Clippy is upset about not checking the return from `tokio::spawn()` in [jobs.rs](https://github.com/profianinc/benefice/blob/d76fbd742f061acf07cf1510d72aa58f83ae9770/src/job.rs#L163), but the spawned job does run and the calling object has a handle to close it when needed.

Getting `aes-gcm`, `axum`, and `base64` updated will also be a challenge due to the breaking changes introduced.